### PR TITLE
coding standard: Add a .editorconfig based on the Nuttx code standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# This file provide reference settings for the Nuttx code conventions
+# There are plug-ins available for nearly every text editor to automatically
+# respect the conventions contained within this file.
+#
+# Please see editorconfig.org for complete information on how to use this file.
+# For the Nuttx coding standard see: http://nuttx.org/doku.php?id=documentation:codingstandard
+#
+# If you find errors in this file, please send a pull-request with a fix.
+#
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_size = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+


### PR DESCRIPTION
This file provide reference settings for the Nuttx code conventions
There are plug-ins (with source) available for nearly every text editor
to automatically respect the conventions contained within this file.

Please see editorconfig.org for complete information on how to use this file.
For the Nuttx coding standard see: http://nuttx.org/doku.php?id=documentation:codingstandard
