### PR TITLE
build: serialize generation of mkconfig and config.h

### DIFF
--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -352,6 +352,8 @@ include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)
 # part of the overall NuttX configuration sequence. Notice that the
 # tools/mkconfig tool is built and used to create include/nuttx/config.h
 
+.NOTPARALLEL: tools/mkconfig$(HOSTEXEEXT) include/nuttx/config.h
+
 tools/mkconfig$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)"  mkconfig$(HOSTEXEEXT)
 


### PR DESCRIPTION
Do not let the rule to trigger twice risking to generate mkconfig again
and replacing it while the other job was already using it to create
config.h.